### PR TITLE
Require backports

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,9 +20,11 @@ requirements:
   build:
     - python
     - setuptools
+    - backports
 
   run:
     - python
+    - backports
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:


### PR DESCRIPTION
Pulls in the `backports` package, which ensures the `backports` namespace is available in advance.